### PR TITLE
Update JSDom

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
   },
   "dependencies": {
     "glob": "^7.2.0",
-    "jsdom": "16.4.0"
+    "jsdom": "16.5.0"
   }
 }


### PR DESCRIPTION
Insufficient Granularity of Access Control in JSDom with v16.4.0.
Dependabot:
> "JSDom improperly allows the loading of local resources, which allows
> for local files to be manipulated by a malicious web page when script
> execution is enabled."