### PR TITLE
Move rescript-js to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,14 +21,14 @@
   "author": "bloodyowl <bloodyowl@icloud.com>",
   "license": "MIT",
   "devDependencies": {
-    "rescript": "^10.0.0",
-    "rescript-js": "1.0.0-beta.2"
+    "rescript": "^10.0.0"
   },
   "peerDependencies": {
     "rescript": "^9.0.0 || ^10.0.0"
   },
   "dependencies": {
     "glob": "^7.2.0",
-    "jsdom": "20.0.0"
+    "jsdom": "20.0.0",
+    "rescript-js": "1.0.0-beta.2"
   }
 }


### PR DESCRIPTION
rescript-js is a runtime dependency of rescript-test. Because it was listed on devDependencies, after adding it to a project you would end up without rescript-js in node_modules.

Fixes #13 