### PR TITLE
Add more allowed file suffixes

### DIFF
--- a/bin/retest.mjs
+++ b/bin/retest.mjs
@@ -11,7 +11,7 @@ let options = {
   "--with-dom": "--with-dom",
 };
 
-let allowedSuffixes = [".bs.js", ".js", ".mjs", ".cjs"];
+let allowedSuffixes = [".res.js", ".res.mjs", ".bs.js", ".js", ".mjs", ".cjs"];
 
 let firstFile = args.filter((item) => !options[item])[0];
 


### PR DESCRIPTION
Extends by `.res.mjs` and `.res.js` as suggested by https://rescript-lang.org/docs/manual/latest/installation#new-project .

Closes #22